### PR TITLE
add long commit hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,4 @@ keywords = ["build", "date", "time", "commit", "datetime"]
 repository = "https://github.com/LivingInSyn/rbtag"
 
 [dependencies]
-rbtag_derive = "0.3.0"
-#rbtag_derive = {path= "rbtag_derive"}
+rbtag_derive = { path = "rbtag_derive" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbtag"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Jeremy Mill <jeremy.mill@otis.com>"]
 edition = "2018"
 description = "A procedural macro to add build DateTime and git commit information at compile time"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RBTAG
-rbtag is a procedural macro designed to add build time information or git commit information to your crate or project. 
+rbtag is a procedural macro designed to add build time information or git commit information to your crate or project.
 
-## Git Commit Info 
+## Git Commit Info
 To use the Git commit Info functionality just add `#[derive(BuildInfo)]` to a struct and call `.get_build_commit()` on it. The output looks like the following:
 
 ```shell
@@ -29,11 +29,15 @@ To use the Git commit Info functionality just add `#[derive(BuildDateTime)]` to 
 The following is an example of running the below 'example' code with and without an environmental variable set
 ```shell
 #$ cargo clean && env SOURCE_DATE_EPOCH='12345678909' cargo run
-12345678901
-90c2266-dirty
+12345678909
+395e50bbf569
+395e50bbf569a792c24518a9ee8f5aff7068694a-clean
+
 #? cargo clean && cargo run
-1547647585
-90c2266-dirty
+1548704908
+395e50bbf569
+395e50bbf569a792c24518a9ee8f5aff7068694a-clean
+
 ```
 
 ## Example
@@ -46,6 +50,7 @@ struct BuildTag;
 fn main() {
     println!("{}", BuildTag{}.get_build_timestamp());
     println!("{}", BuildTag{}.get_build_commit());
+    println!("{}", BuildTag{}.get_build_commit_long());
 }
 
 ```

--- a/rbtag_derive/Cargo.toml
+++ b/rbtag_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbtag_derive"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Jeremy Mill <jeremy.mill@otis.com>"]
 edition = "2018"
 description = "A procedural macro impl to add git and build datetime info"

--- a/rbtag_derive/src/lib.rs
+++ b/rbtag_derive/src/lib.rs
@@ -44,7 +44,7 @@ fn get_time_info() -> String {
     }
 }
 
-/// This function creates a utc datetime in rfc3339 format and returns it as a 
+/// This function creates a utc datetime in rfc3339 format and returns it as a
 /// `&'static str`
 #[proc_macro_derive(BuildDateTime)]
 pub fn build_dt(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -62,7 +62,7 @@ pub fn build_dt(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 }
 
 fn get_commit_info() -> String {
-    let git_commit_command = "git show -s --format=%h";
+    let git_commit_command = "git show -s --format=%H";
     let git_dirty_command = "git diff-index --quiet HEAD --";
     // get the git commit/datetime info
     let commit_output = if cfg!(target_os = "windows") {
@@ -104,15 +104,18 @@ fn get_commit_info() -> String {
 /// or *nix and returns it as a `&'static str`
 #[proc_macro_derive(BuildInfo)]
 pub fn get_build_commit(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let gitoutput = get_commit_info();
+    let git_commit_hash_long = get_commit_info();
+    let git_commit_hash_short = git_commit_hash_long[..12].to_string();
     let input = parse_macro_input!(input as DeriveInput);
     let name = input.ident;
-    //let stdout = String::from_utf8_lossy(&output.stdout);
     let expanded = quote! {
         impl BuildInfo for #name {
             fn get_build_commit(&self) -> &'static str {
-                //String::from("test")
-                #gitoutput
+                #git_commit_hash_short
+            }
+
+            fn get_build_commit_long(&self) -> &'static str {
+                #git_commit_hash_long
             }
         }
     };

--- a/rbtag_example/Cargo.toml
+++ b/rbtag_example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbtag_example"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Jeremy Mill <jeremy.mill@otis.com>"]
 edition = "2018"
 

--- a/rbtag_example/src/main.rs
+++ b/rbtag_example/src/main.rs
@@ -6,4 +6,5 @@ struct BuildTag;
 fn main() {
     println!("{}", BuildTag{}.get_build_timestamp());
     println!("{}", BuildTag{}.get_build_commit());
+    println!("{}", BuildTag{}.get_build_commit_long());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,4 +9,5 @@ pub trait BuildDateTime {
 /// Trait for returning the build commit short hash
 pub trait BuildInfo {
     fn get_build_commit(&self) -> &'static str;
+    fn get_build_commit_long(&self) -> &'static str;
 }


### PR DESCRIPTION
Adds new trait fxn:

```rust
BuildTag{}.get_build_commit_long()
```

...to get the same output as before, except using the long git hash.